### PR TITLE
Decrypt before deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ cache:
   - "$HOME/.sbt/boot/"
   - "$HOME/.coursier/"
 before_script: 
-before_deploy: 
+before_deploy:
+- openssl aes-256-cbc -K $encrypted_e1b7aa05673b_key -iv $encrypted_e1b7aa05673b_iv
+  -in secring.asc.enc -out secring.asc -d
 deploy:
 - provider: script
   script: sbt ++$TRAVIS_SCALA_VERSION "sonatypeOpen \"Travis Job $TRAVIS_JOB_NAME
@@ -26,6 +28,3 @@ deploy:
   on:
     all_branches: true
     condition: "$SONATYPE_USERNAME"
-before_install:
-- openssl aes-256-cbc -K $encrypted_e1b7aa05673b_key -iv $encrypted_e1b7aa05673b_iv
-  -in secring.asc.enc -out secring.asc -d


### PR DESCRIPTION
This change fixes Travis CI when the passphrase is not present, e.g. when running a pull request
https://travis-ci.com/Atry/nameBasedXml.scala/builds/133353008